### PR TITLE
POST and PUT now send data in the body insted of parameters in the uri

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ python:
   - "3.5"
 
 before_install:
-  - ./build_etcd.sh v2.2.0
+  - ./build_etcd.sh v3.1.1
 
 # command to install dependencies
 install:

--- a/build_etcd.sh
+++ b/build_etcd.sh
@@ -12,7 +12,7 @@ echo "Using ETCD version $ETCD_VERSION"
 git clone https://github.com/coreos/etcd.git
 cd etcd
 git checkout $ETCD_VERSION
-BINDIR=/usr/bin ./build
+./build
 
 
 : ${TRAVIS:?"This is not a Travis build. All Done"}

--- a/build_etcd.sh
+++ b/build_etcd.sh
@@ -12,7 +12,7 @@ echo "Using ETCD version $ETCD_VERSION"
 git clone https://github.com/coreos/etcd.git
 cd etcd
 git checkout $ETCD_VERSION
-./build
+BINDIR=/usr/bin ./build
 
 
 : ${TRAVIS:?"This is not a Travis build. All Done"}

--- a/src/etcd/auth.py
+++ b/src/etcd/auth.py
@@ -130,7 +130,13 @@ class EtcdUser(EtcdAuthBase):
 
     @roles.setter
     def roles(self, val):
-        self._roles = set(val)
+        def extract_roles(r):
+            if isinstance(r, dict):
+                return r.get("role")
+            else:
+                return r
+
+        self._roles = set(set(map(lambda x: extract_roles(x), val)))
 
     @property
     def password(self):

--- a/src/etcd/client.py
+++ b/src/etcd/client.py
@@ -846,13 +846,26 @@ class Client(object):
 
         url = self._base_uri + path
 
-        return self._client.request(
-            method,
-            url,
-            params=params,
-            auth=self._get_auth(),
-            allow_redirects=self.allow_redirect,
-            )
+        if (method == self._MGET) or (method == self._MDELETE):
+            return self._client.request(
+                method,
+                url,
+                params=params,
+                auth=self._get_auth(),
+                allow_redirects=self.allow_redirect,
+                )
+
+        elif (method == self._MPUT) or (method == self._MPOST):
+            return self._client.request(
+                method,
+                url,
+                data=params,
+                auth=self._get_auth(),
+                allow_redirects=self.allow_redirect,
+                )
+        else:
+            raise etcd.EtcdException(
+                'HTTP method {} not supported'.format(method))
 
     @_wrap_request
     def api_execute_json(self, path, method, params=None):

--- a/src/etcd/tests/integration/helpers.py
+++ b/src/etcd/tests/integration/helpers.py
@@ -28,7 +28,7 @@ class EtcdProcessHelper(object):
     def __init__(
             self,
             base_directory,
-            proc_name='aio_etcd',
+            proc_name='etcd',
             port_range_start=4001,
             internal_port_range_start=7001,
             cluster=False,

--- a/src/etcd/tests/integration/test_ssl.py
+++ b/src/etcd/tests/integration/test_ssl.py
@@ -18,7 +18,6 @@ class TestEncryptedAccess(test_simple.EtcdIntegrationTest):
 
     @classmethod
     def setUpClass(cls):
-        program = cls._get_exe()
         cls.directory = tempfile.mkdtemp(prefix='python-aio_etcd')
 
         cls.ca_cert_path = os.path.join(cls.directory, 'ca.crt')
@@ -41,8 +40,7 @@ class TestEncryptedAccess(test_simple.EtcdIntegrationTest):
 
         cls.processHelper = helpers.EtcdProcessHelper(
             cls.directory,
-            proc_name=program,
-            port_range_start=6001,
+            port_range_start=6281,
             internal_port_range_start=8001,
             tls=True
         )
@@ -57,7 +55,7 @@ class TestEncryptedAccess(test_simple.EtcdIntegrationTest):
     def test_get_set_unauthenticated(loop, self):
         """ INTEGRATION: set/get a new value unauthenticated (http->https) """
 
-        client = aio_etcd.Client(port=6001, loop=loop)
+        client = aio_etcd.Client(port=6281, loop=loop)
 
         # Since python 3 raises a MaxRetryError here, this gets caught in
         # different code blocks in python 2 and python 3, thus messages are
@@ -78,7 +76,7 @@ class TestEncryptedAccess(test_simple.EtcdIntegrationTest):
     def test_get_set_unauthenticated_missing_ca(loop, self):
         """ INTEGRATION: try unauthenticated w/out validation (https->https)"""
         # This doesn't work for now and will need further inspection
-        client = aio_etcd.Client(protocol='https', port=6001, ssl_verify=ssl.CERT_NONE, loop=loop)
+        client = aio_etcd.Client(protocol='https', port=6281, ssl_verify=ssl.CERT_NONE, loop=loop)
         set_result = yield from client.set('/test_set', 'test-key')
         get_result = yield from client.get('/test_set')
 
@@ -86,7 +84,7 @@ class TestEncryptedAccess(test_simple.EtcdIntegrationTest):
     def test_get_set_unauthenticated_with_ca(loop, self):
         """ INTEGRATION: try unauthenticated with validation (https->https)"""
         client = aio_etcd.Client(
-            protocol='https', port=6001, ca_cert=self.ca2_cert_path, loop=loop)
+            protocol='https', port=6281, ca_cert=self.ca2_cert_path, loop=loop)
 
         loop = asyncio.get_event_loop()
         try:
@@ -105,7 +103,7 @@ class TestEncryptedAccess(test_simple.EtcdIntegrationTest):
         """ INTEGRATION: set/get a new value authenticated """
 
         client = aio_etcd.Client(
-            port=6001, protocol='https', ca_cert=self.ca_cert_path, loop=loop)
+            port=6281, protocol='https', ca_cert=self.ca_cert_path, loop=loop)
 
         set_result = yield from client.set('/test_set', 'test-key')
         get_result = yield from client.get('/test_set')
@@ -115,7 +113,6 @@ class TestClientAuthenticatedAccess(test_simple.EtcdIntegrationTest):
 
     @classmethod
     def setUpClass(cls):
-        program = cls._get_exe()
         cls.directory = tempfile.mkdtemp(prefix='python-aio_etcd')
 
         cls.ca_cert_path = os.path.join(cls.directory, 'ca.crt')
@@ -143,8 +140,7 @@ class TestClientAuthenticatedAccess(test_simple.EtcdIntegrationTest):
 
         cls.processHelper = helpers.EtcdProcessHelper(
             cls.directory,
-            proc_name=program,
-            port_range_start=6001,
+            port_range_start=6281,
             internal_port_range_start=8001,
             tls=True
         )
@@ -167,7 +163,7 @@ class TestClientAuthenticatedAccess(test_simple.EtcdIntegrationTest):
     def test_get_set_unauthenticated(loop, self):
         """ INTEGRATION: set/get a new value unauthenticated (http->https) """
 
-        client = aio_etcd.Client(port=6001, loop=loop)
+        client = aio_etcd.Client(port=6281, loop=loop)
 
         # See above for the reason of this change
         try:
@@ -189,7 +185,7 @@ class TestClientAuthenticatedAccess(test_simple.EtcdIntegrationTest):
         # doesn't fail
 
         client = aio_etcd.Client(
-            port=6001,
+            port=6281,
             protocol='https',
             cert=self.client_all_cert,
             ca_cert=self.ca_cert_path,

--- a/src/etcd/tests/integration/test_ssl.py
+++ b/src/etcd/tests/integration/test_ssl.py
@@ -18,6 +18,7 @@ class TestEncryptedAccess(test_simple.EtcdIntegrationTest):
 
     @classmethod
     def setUpClass(cls):
+        program = cls._get_exe()
         cls.directory = tempfile.mkdtemp(prefix='python-aio_etcd')
 
         cls.ca_cert_path = os.path.join(cls.directory, 'ca.crt')
@@ -40,6 +41,7 @@ class TestEncryptedAccess(test_simple.EtcdIntegrationTest):
 
         cls.processHelper = helpers.EtcdProcessHelper(
             cls.directory,
+            proc_name=program,
             port_range_start=6281,
             internal_port_range_start=8001,
             tls=True
@@ -113,6 +115,7 @@ class TestClientAuthenticatedAccess(test_simple.EtcdIntegrationTest):
 
     @classmethod
     def setUpClass(cls):
+        program = cls._get_exe()
         cls.directory = tempfile.mkdtemp(prefix='python-aio_etcd')
 
         cls.ca_cert_path = os.path.join(cls.directory, 'ca.crt')
@@ -140,6 +143,7 @@ class TestClientAuthenticatedAccess(test_simple.EtcdIntegrationTest):
 
         cls.processHelper = helpers.EtcdProcessHelper(
             cls.directory,
+            proc_name=program,
             port_range_start=6281,
             internal_port_range_start=8001,
             tls=True


### PR DESCRIPTION
Writing a medium size json.dump was failing.
Seems that was too big for a param, or maybe some character was not correctly escaped.

Python-etcd use the [same way](https://github.com/jplana/python-etcd/blob/642048626572a1297aa10fcf609b5df3afe25536/src/etcd/client.py#L925), using body for POST and PUT.