### PR TITLE
bug fix lock.acquire

### DIFF
--- a/src/etcd/lock.py
+++ b/src/etcd/lock.py
@@ -72,7 +72,7 @@ class Lock(object):
             await self.client.write(self.lock_key, self.uuid, ttl=lock_ttl)
 
         # now get the owner of the lock, and the next lowest sequence
-        return self._acquired(blocking=blocking)
+        return await self._acquired(blocking=blocking)
 
     async def release(self):
         """


### PR DESCRIPTION
`await lock.acquire()` return lock._acquired(),  but this is never awaited

`return await lock._acquired()` works fine